### PR TITLE
feat: Layout Component complete

### DIFF
--- a/src/components/common/Layout/Layout.style.ts
+++ b/src/components/common/Layout/Layout.style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Layout = styled.section`
-  max-width: 390px;
+  max-width: 375px;
   padding: 0 21px;
   margin: 0 auto;
 `;

--- a/src/components/common/Layout/Layout.style.ts
+++ b/src/components/common/Layout/Layout.style.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const Layout = styled.section`
+  padding: 0 21px;
+`;

--- a/src/components/common/Layout/Layout.style.ts
+++ b/src/components/common/Layout/Layout.style.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Layout = styled.section`
+  max-width: 390px;
   padding: 0 21px;
+  margin: 0 auto;
 `;

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import * as S from './Layout.style';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => <S.Layout>{children}</S.Layout>;
+
+export default Layout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { AppProps } from 'next/app';
 
+import Layout from '@/components/common/Layout';
 import { server } from '@/mocks/browsers/testServer';
 import GlobalStore from '@/store/GlobalStore';
 import QueryProvider from '@/utils/QueryProvider';
@@ -29,7 +30,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     <QueryProvider>
       <ThemeProvider theme={{ mode: theme }}>
         <Global styles={{}} />
-        <Component {...pageProps} />
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
       </ThemeProvider>
     </QueryProvider>
   );


### PR DESCRIPTION
모든 페이지를 감싸는 Layout 컴포넌트를 만들어 봤는데, 막상 공통으로 사용하는게 패딩 값 뿐이라고 들어서
패딩값만 우선 주었습니다..
모든 컴포넌트를 감싸는데 있어서 요렇게 Layout을 만드는거 말고 다르게 만드는 좋은 방법이 있을까요